### PR TITLE
[FEAT] Implement chat_id Logic in Frontend for Persistent Sessions

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,15 +4,23 @@ import axios from "axios";
 // const API_URL = import.meta.env.VITE_API_URL?.trim() || "/api";
 const API_URL = "/api";
 
-export const uploadPDF = async (file: File) => {
+export const uploadPDF = async (file: File, chatId?: string) => {
     const formData = new FormData();
     formData.append("file", file);
+
+    // If we already have a chat_id, include it
+    if (chatId) {
+        formData.append("chat_id", chatId);
+    }
 
     return await axios.post(`${API_URL}/pdf/upload/`, formData, {
         headers: { "Content-Type": "multipart/form-data" }
     });
 };
 
-export const askQuestion = async (question: string) => {
-    return await axios.post(`${API_URL}/chat/ask/`, { question });
+export const askQuestion = async (question: string, chatId?: string) => {
+    return await axios.post(`${API_URL}/chat/ask/`, {
+      chat_id: chatId, // if undefined, backend might complain, so ideally pass empty string or null if not available
+      question,
+    });
 };


### PR DESCRIPTION
## 🔗 Issue Reference  
Fixes #9 

## Description

This pull request integrates the `chat_id` mechanism into our React + Vite frontend to ensure users can maintain continuous conversations across multiple PDF uploads and queries. The changes include:

- **Storing** `chat_id` in `localStorage` upon PDF upload.
- **Reusing** `chat_id` on subsequent file uploads or chat questions to preserve session context.
- **Alerting** the user if no `chat_id` is found (i.e., they must upload a PDF first).

## Implementation Details

1. **Upload.tsx**  
   - Added logic to read `chat_id` from `localStorage` if it exists.  
   - Appended `chat_id` to the `FormData` when calling the upload endpoint.  
   - Stored the new/returned `chat_id` in `localStorage`.

2. **Chat.tsx**  
   - On each question (`handleSend`), retrieved the `chat_id` from `localStorage`.  
   - Passed `chat_id` with the user’s query to the backend.  
   - If no `chat_id` is found, displayed a warning for the user to upload a PDF first.

3. **No Major UI Changes**  
   - The styling and layout remain the same; only the internal logic for session handling has been updated.

## Testing

- **Local Testing via Postman**  
  1. Uploaded a PDF, verified the `chat_id` is returned, and stored in `localStorage`.  
  2. Asked a follow-up question with the same `chat_id`; the context was retained.  
- **Manual Browser Testing**  
  - Refreshed the page; the existing `chat_id` was still in `localStorage`.  
  - Uploaded a second PDF; confirmed the same session was used.

## Additional Notes

- Future improvements may include clearing the `chat_id` if the user explicitly starts a “New Session” or logs out.  
- Ensured backward compatibility for users who have not yet uploaded any PDFs (they see an alert prompting them to upload).

---
